### PR TITLE
Restrict deployment to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
                 echo "### File viewable at: https://cern.ch/feickert/ATLAS/thesis/PRs/draft_PR${CIRCLE_PULL_REQUEST##*/}.pdf"
                 SSHPASS=$PHYSSERVER_PASS sshpass -e scp abstract.pdf mfeickert@rubin.physics.smu.edu:/users/mfeickert/public_html/thesis/PRs/abstract_PR${CIRCLE_PULL_REQUEST##*/}.pdf
                 echo "### File viewable at: https://www.physics.smu.edu/mfeickert/thesis/PRs/draft_PR${CIRCLE_PULL_REQUEST##*/}.pdf"
-              else
+              elif [[ "$CIRCLE_BRANCH" == "master" ]]; then
                 SSHPASS=$LXPLUS_PASS sshpass -e scp feickert_thesis.pdf feickert@lxplus.cern.ch:/eos/user/f/feickert/www/ATLAS/thesis/draft.pdf
                 SSHPASS=$LXPLUS_PASS sshpass -e scp abstract.pdf feickert@lxplus.cern.ch:/eos/user/f/feickert/www/ATLAS/thesis/abstract.pdf
                 echo "### File viewable at: https://cern.ch/feickert/ATLAS/thesis/draft.pdf"


### PR DESCRIPTION
The deployment to master should only occur during a PR merge or a push to master. This fixes an issue where a build would be triggered on another branch that would be turned into a PR but before the PR existed and so the control logic would still deploy to the master build location.