### PR TITLE
Move commas outside quotes inside

### DIFF
--- a/src/ATLAS.tex
+++ b/src/ATLAS.tex
@@ -68,7 +68,7 @@ Combined with the precision tracking from the pixel detectors and SCT, the track
 The ATLAS calorimeter system, shown in \Cref{fig:ATLAS_calorimeter}, provides excellent energy deposition measurements for particles with coverage up to $\abs{\eta} < 4.9$ with different calorimetry subsystems for various physics processes.
 In the pseudorapidity range of the inner detector ($\abs{\eta} < 2.5$) the high granularity electromagnetic (EM) liquid argon calorimeter system provides measurement of electrons and photons.
 The more coarse resolution of the hadronic calorimeter systems provides measurements for jet reconstruction and missing transverse momentum, $\MET$, in conjunction with the large pseudorapidity coverage.
-These calorimeter designs are both ``sampling calorimeters'', where the ``active'' materials that provide the signals are different from the ``absorber'' materials that reduce the particle energy and cause showering.
+These calorimeter designs are both ``sampling calorimeters,'' where the ``active'' materials that provide the signals are different from the ``absorber'' materials that reduce the particle energy and cause showering.
 The calorimeter subsystems are also designed to be sufficiently thick as to contain the electromagnetic and hadronic showers that originate inside them, and to limit punch-through to the muon systems.
 
 \begin{figure}[htbp]
@@ -116,7 +116,7 @@ More specifically, the energy resolution, $\sigma\left(E\right)$, of a calorimet
  \frac{\sigma\left(E\right)}{E} = \frac{a}{\sqrt{E}} \oplus \frac{b}{E} \oplus c\,,
  \label{eq:calorimeter_energy_resolution}
 \end{equation}
-where $a$ is the ``stochastic term'' for intrinsic shower fluctuations, $b$ is the ``noise term'', and $c$ is the ``constant'' term~\cite{Fabjan:692252}.
+where $a$ is the ``stochastic term'' for intrinsic shower fluctuations, $b$ is the ``noise term,'' and $c$ is the ``constant'' term~\cite{Fabjan:692252}.
 It is seen from \Cref{eq:calorimeter_energy_resolution} that at lower energies the stochastic term is more important and at higher energies the constant term affects the energy resolution more.
 The ATLAS calorimeters are designed to have excellent energy resolution, which is clearly seen from the observed energy resolution for the ATLAS LAr EM calorimeter barrel region in testbeam experiments~\cite{Ilic:2014,Aleksa:1547314}
 \[
@@ -149,7 +149,7 @@ For most of the $\eta$ range the MDTs perform most of the precision measurements
   Solid curves indicate the total stopping power.
   Data below the break at $\beta \gamma \approx 0.1$ are taken from ICRU 49~\cite{ICRU49}, and data at higher energies are from~\cite{Groom:2001kq}.
   Vertical bands indicate boundaries between different approximations discussed in~\cite{PDG2018:Ch33}.
-  The short dotted lines labeled ``$\mu^{-}$'' illustrate the ``Barkas effect'', the dependence of stopping power on projectile charge at very low energies~\cite{PhysRev.101.778}.
+  The short dotted lines labeled ``$\mu^{-}$'' illustrate the ``Barkas effect,'' the dependence of stopping power on projectile charge at very low energies~\cite{PhysRev.101.778}.
   $dE/dx$ in the radiative region is not simply a function of $\beta$~\cite{PDG2018:Ch33}.}\label{fig:Bethe-Bloch_stopping_power}
 \end{figure}
 

--- a/src/appendix/trigger.tex
+++ b/src/appendix/trigger.tex
@@ -25,7 +25,7 @@ The purpose of the $b$-jet trigger to provide effective $b$-jet identification a
 This still needs to be done quickly, but given that $b$-tagging is being performed on each jet candidate that passes other selection criteria tracking must also be performed.
 As a result, the $b$-jet triggers are the leading consumers of CPU out of all triggers in the ATLAS trigger menu.
 In Run 2 to address this issue a new CPU and time saving measure was introduced~\cite{Hetherly:2313140}.
-Instead of running the track matching algorithms in each \gls{RoI} that existed for the event, even if there was substantial overlap between the RoIs, all RoIs --- regardless of if they have topologically overlap --- are merged into a single ``Super-RoI'', as seen in \Cref{fig:all_ROI_vs_superROI}.
+Instead of running the track matching algorithms in each \gls{RoI} that existed for the event, even if there was substantial overlap between the RoIs, all RoIs --- regardless of if they have topologically overlap --- are merged into a single ``Super-RoI,'' as seen in \Cref{fig:all_ROI_vs_superROI}.
 Once the Super-RoI has been created, fast tracking is run in the Super-RoI to find a primary vertex.
 Once a primary vertex has been found, precision tracking is then run in each of the original RoIs, but with the tracks constrained by the Super-RoI primary vertex.
 

--- a/src/event_reconstruction.tex
+++ b/src/event_reconstruction.tex
@@ -83,7 +83,7 @@ Muons are also further calibrated to data using $J/\Psi \to \mu^{+}\mu^{-}$ to c
 As particles that carry \gls{QCD} color charge do not exist by themselves in isolation, but combine with other colored particles to form colorless composite particles known as ``hadrons,'' it is not possible to directly observe quarks or gluons in ATLAS.
 Instead, this process of hadronization, and subsequent decays and rehadronization, creates a shower of both charged and neutral particles that hit the detector, creating charged tracks and energy deposits.
 These hadronic showers are stochastic, and there is no way to give a full descriptive definition of them, though there is very impressive recent work on operational definitions~\cite{Metodiev:2018ftz,Komiske:2018vkc,Larkoski:2019nwj}.
-Instead, clustering algorithms are used to create collections of tracks and energy deposits, known as ``jets'', based off of the criteria of interest in the algorithm.
+Instead, clustering algorithms are used to create collections of tracks and energy deposits, known as ``jets,'' based off of the criteria of interest in the algorithm.
 In a similar manner to how QCD's depth and richness as a theory requires proper treatment outside the scope of this thesis, jet physics is complex and deep enough to rightly be its own intense physics program at the LHC.
 This section will only attempt to give an executive summary of the jet physics and techniques that is pertinent to my thesis analysis --- however for an exceedingly thorough overview see~\cite{Nachman:2016qyc}.
 
@@ -136,8 +136,8 @@ A typical choice of jet algorithm in ATLAS is the anti-$k_{t}$ algorithm with si
    The sample parton-level event clustered with the anti-$k_{t}$ jet algorithm.}
   \label{fig:jet_algorithms_anti_kt}
  \end{subfigure}%
- \caption[A sample parton-level event, together with many random soft ``ghosts'', clustered with three different jet algorithms, illustrating the ``active'' catchment areas of the resulting hard jets.]{%
-  A sample parton-level event (generated with Herwig), together with many random soft ``ghosts'', clustered with the $k_{t}$, Cambridge/Aachen, and anti-$k_{t}$ jet algorithms, illustrating the ``active'' catchment areas of the resulting hard jets.
+ \caption[A sample parton-level event, together with many random soft ``ghosts,'' clustered with three different jet algorithms, illustrating the ``active'' catchment areas of the resulting hard jets.]{%
+  A sample parton-level event (generated with Herwig), together with many random soft ``ghosts,'' clustered with the $k_{t}$, Cambridge/Aachen, and anti-$k_{t}$ jet algorithms, illustrating the ``active'' catchment areas of the resulting hard jets.
   For $k_{t}$ and Cambridge/Aachen the detailed shapes are in part determined by the specific set of ghosts used, and change when the ghosts are modified~\cite{Cacciari:2008gp}.}
  \label{fig:jet_algorithms}
 \end{figure}

--- a/src/theory.tex
+++ b/src/theory.tex
@@ -139,7 +139,7 @@ QCD is a deeply rich theory that deserves much attention (c.f.~\cite{Campbell:20
 \section{Spontaneous Symmetry Breaking}\label{section:symmetry_breaking}
 
 Spontaneous symmetry breaking is the process by which a physical system that has a symmetry does not express that symmetry for perturbations around the ground state of the system.
-It is worth noting, given the somewhat confusing nature of the use of ``breaking'', that the symmetry of the Lagrangian is not destroyed under symmetry breaking, but rather is not manifest given the ground state the system has been perturbed into.
+It is worth noting, given the somewhat confusing nature of the use of ``breaking,'' that the symmetry of the Lagrangian is not destroyed under symmetry breaking, but rather is not manifest given the ground state the system has been perturbed into.
 A classical example of spontaneous symmetry breaking is that of a pen being balanced upright on its tip on a table.
 In the unstable equilibrium state of the pen being balanced (the high energy/excited state configuration) the pen possesses a $\mathrm{U}(1)$ symmetry of rotation about its axis.
 If the pen is perturbed from this state by a small vibration it will fall into its ground state onto the surface of the table and will lie along some direction ``breaking'' the symmetry that was exhibited by the previous state.


### PR DESCRIPTION
# Description

Correct punctuation by having commas trailing quotes be brought inside.