### PR TITLE
Revise post deposit from Vernieri comments

### DIFF
--- a/figures/theory/H_photons.tex
+++ b/figures/theory/H_photons.tex
@@ -15,7 +15,7 @@
   \vertex [right=1.75cm of v2] (gamma2) {\(\gamma\)};
   \diagram* {
   (origin) -- [scalar, edge label={\(H\)}] (H),
-  (H) -- [fermion] (v1) -- [fermion] (v2) -- [fermion] (H),
+  (H) -- [boson] (v2) -- [boson, edge label={\(W\)}] (v1) -- [boson] (H),
   (gamma1) -- [photon] (v1),
   (gamma2) -- [photon] (v2),
   };

--- a/src/event_reconstruction.tex
+++ b/src/event_reconstruction.tex
@@ -279,7 +279,7 @@ The beam pipe that was installed with the \gls{IBL} in 2014 is mostly made of $0
 Given the characteristic length scale of $b$-hadrons most%
 \footnote{A typical $B$ meson $\left(m = 5~\GeV, \tau = 1.5~\mathrm{ps}\right)$ would require $p_{T} \gtrsim 280~\GeV$ to decay outside the beam pipe.}
 decay inside of the beam pipe.
-This secondary vertex is still detectable as the vertex resolution in ATLAS for $50$ associated tracks is approximately $20~\mu\mathrm{m}$ in $r$-$\phi$ by $30~\mu\mathrm{m}$ in $z$~\cite{Choi:2271033,ATL-PHYS-PUB-2015-026}, as seen in \Cref{fig:primary_vertex_resolution}.
+This secondary vertex is still detectable as the vertex resolution in ATLAS for $5$ to $10$ associated tracks --- typical of a SV in a $b$-jet~\cite{ATL-PHYS-PUB-2017-013} --- is approximately $65~\mu\mathrm{m}$ in $r$-$\phi$ by $110~\mu\mathrm{m}$ in $z$~\cite{Choi:2271033,ATL-PHYS-PUB-2015-026}, as seen in \Cref{fig:primary_vertex_resolution}.
 $B$ mesons also have a mass of approximately $5~\GeV$.
 Collectively, these properties can be exploited by $b$-tagging algorithms to discriminate $b$-jets from light or charm jets~\cite{ATL-PHYS-PUB-2015-022,ATL-PHYS-PUB-2016-012,ATL-PHYS-PUB-2017-013,PERF-2016-05}.
 


### PR DESCRIPTION
# Description

Address comments received post deposit of thesis.

https://www.cern.ch/feickert/ATLAS/thesis/PRs/draft_PR91.pdf

- Higgs decay to diphoton through W loop is more dominant than through a heavy fermion loop, so the W loop should be used in the Feynman diagram.
- Revise SV resolution conditioned on number of tracks typically associated to it in a b-jet.